### PR TITLE
host_machine

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -96,7 +96,7 @@ lib_src = [
   'lib/http2/http2_debug_state.c'
 ]
 
-osdet = build_machine.system()
+osdet = host_machine.system()
 cc = meson.get_compiler('c')
 
 inc = include_directories([


### PR DESCRIPTION
host_machine is the machine the binary will run on. They're of course identical unless we're cross compiling.